### PR TITLE
Update Fairness Docs

### DIFF
--- a/docs/fairness/aequitas.md
+++ b/docs/fairness/aequitas.md
@@ -71,16 +71,10 @@ Quick and easy assessment of fairness in dataset or model predictions. Can quick
 
 ## Case study demo with screenshots
 
-IMAGE NEEDED
+![alt_text](../_media/image12.png "image_tooltip")
 
-![alt_text](_media/image12.png "image_tooltip")
+![alt_text](../_media/image13.png "image_tooltip")
 
-IMAGE NEEDED
-
-![alt_text](_media/image13.png "image_tooltip")
-
-IMAGE NEEDED
-
-![alt_text](_media/image14.png "image_tooltip")
+![alt_text](../_media/image14.png "image_tooltip")
 
 ##

--- a/docs/fairness/fairlearn.md
+++ b/docs/fairness/fairlearn.md
@@ -57,8 +57,6 @@ Add in screenshots with descriptions on the data set used!
 
 IMAGE NEEDED
 
-![alt_text](_media/image17.png "image_tooltip")
+![alt_text](../_media/image17.png "image_tooltip")
 
-IMAGE NEEDED
-
-![alt_text](_media/image18.png "image_tooltip")
+![alt_text](../_media/image18.png "image_tooltip")

--- a/docs/fairness/ibm.md
+++ b/docs/fairness/ibm.md
@@ -84,10 +84,6 @@ Perhaps a steep learning curve in terms of integrating into an existing model bu
 
 **Case study demo with screenshots**
 
-IMAGE NEEDED
+![alt_text](../_media/image10.png "image_tooltip")
 
-![alt_text](_media/image10.png "image_tooltip")
-
-IMAGE NEEDED
-
-![alt_text](_media/image11.png "image_tooltip")
+![alt_text](../_media/image11.png "image_tooltip")

--- a/docs/fairness/pymetrics.md
+++ b/docs/fairness/pymetrics.md
@@ -79,10 +79,6 @@ Limited to only one form of fairness definition
 
 - The example shows how easy it is to install, import and use the package
 
-IMAGE NEEDED
+![alt_text](../_media/image15.png "image_tooltip")
 
-![alt_text](_media/image15.png "image_tooltip")
-
-IMAGE NEEDED
-
-![alt_text](_media/image16.png "image_tooltip")
+![alt_text](../_media/image16.png "image_tooltip")

--- a/docs/fairness/scikit.md
+++ b/docs/fairness/scikit.md
@@ -51,15 +51,15 @@ This tool is fairly basic, but seems to do what it does well. This tool is best 
 
 Pros:
 
-    * Can integrate fairly seamlessly into an existing logistic regression pipeline
+  * Can integrate fairly seamlessly into an existing logistic regression pipeline
 
-    * Built on top of sklearn
+  * Built on top of sklearn
 
-    * Tackles pre-processing, model building and post-modelling evaluation and correction stages of pipeline
+  * Tackles pre-processing, model building and post-modelling evaluation and correction stages of pipeline
 
-    * Simple Pip install
+  * Simple Pip install
 
-1. **Limitations, especially any technical issues**
+**Limitations, especially any technical issues**
 
 - Fairness optimisation technique is limited to training Logistic Regression Models
 

--- a/docs/fairness/whatif.md
+++ b/docs/fairness/whatif.md
@@ -32,31 +32,23 @@ Visualize feature importance for each model. The partial dependence plot (short 
 
 ![alt_text](../_media/google-whatif-distance.png)
 
-<p id="gdcalert5" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: inline image link here (to _media/image5.png). Store image on your image server and adjust path/filename/extension if necessary. </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert6">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
-
-![alt_text](_media/image5.png "image_tooltip")
+![alt_text](../_media/image5.png "image_tooltip")
 
 Explore data distributions: can visually identify any skews in distributions, e.g. more men than women
 
-IMAGE NEEDED
-
-![alt_text](_media/image6.png "image_tooltip")
+![alt_text](../_media/image6.png "image_tooltip")
 
 IMAGE NEEDED
 
-![alt_text](_media/image7.png "image_tooltip")
+![alt_text](../_media/image7.png "image_tooltip")
 
 -
 
 Compare model performance (confusion matrix, scatterplot, histogram). Experiment using confusion matrices and ROC curves, apply various fairness metrics and thresholds
 
-IMAGE NEEDED
+![alt_text](../_media/image8.png "image_tooltip")
 
-![alt_text](_media/image8.png "image_tooltip")
-
-IMAGE NEEDED
-
-![alt_text](_media/image9.png "image_tooltip")
+![alt_text](../_media/image9.png "image_tooltip")
 
 **Best for (Pros): **
 


### PR DESCRIPTION
* Update image links to search one directory up
* Update Markdown to remove extra spaces which forces code mode

Note that the Fairlearn page is still missing an image as `image17.png` is not present in _media